### PR TITLE
manage messages limit

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,23 @@
+package pushover
+
+import (
+	"fmt"
+
+	"github.com/gregdel/pushover"
+)
+
+type ServerError struct {
+	limitReached bool
+	Errors       pushover.Errors
+}
+
+func (e ServerError) Error() string {
+	if e.limitReached {
+		e.Errors = append(e.Errors, "messages limit reached")
+	}
+	return fmt.Sprintf("pushover server errors: %+v", e.Errors)
+}
+
+func (e ServerError) IsLimitReached() bool {
+	return e.limitReached
+}


### PR DESCRIPTION
Hi,

I'm trying to use this library and I want to distinguish when we reached the messages limit from the other kind of errors.
This lib doesn't permit it because it ignores the `response.Limit` field.
Error handling is done here: https://github.com/hekmon/pushover/blob/master/send.go#L87

Errors from gregdel/pushover are an array of strings: https://github.com/gregdel/pushover/blob/master/errors.go#L8
I don't know if the server also send an error message when the limit is reached, but even if it would works we shouldn't rely on string matching to be able to handle a specific error case.

This PR is a proposal to add an error struct type in the library with some additional fields to be able to process errors in a bit more fine grained way. 
This doesn't break existing code and would allow the user of the library to test the error type.
It would be better to have a field with some kind of error codes but we have only one case to test here.

I'm open to suggestions if this is useful